### PR TITLE
Making the preg_match check for FFmpeg being installed case insensitive

### DIFF
--- a/provider/FFmpegOutputProvider.php
+++ b/provider/FFmpegOutputProvider.php
@@ -35,7 +35,7 @@ class FFmpegOutputProvider extends AbstractOutputProvider {
         $output = join(PHP_EOL, $output);
         
         // ffmpeg installed
-        if (!preg_match('/FFmpeg version/', $output)) {
+        if (!preg_match('/FFmpeg version/i', $output)) {
             throw new Exception('FFmpeg is not installed on host server', self::$EX_CODE_NO_FFMPEG);
         }
         


### PR DESCRIPTION
Making the preg_match check for FFmpeg being installed case insensitive.

Fixes the issue of code not working in distros where the package displays the line 'ffmpeg version' not 'FFmpeg version'. Seen on Ubuntu 10.1, with ffmpeg installed following these instructions http://ubuntuforums.org/showpost.php?p=9868359&postcount=1289
