### PR TITLE
Add composer support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,14 @@ or download package from github.com: ::
 
  $ wget http://github.com/char0n/ffmpeg-php/tarball/master
 
+or to install via composer (http://getcomposer.org/) place the following in your composer.json file: ::
+
+ {
+    "require": {
+        "char0n/ffmpeg-php": "dev-master"
+    }
+ }
+
 
 Using FFmpegPHP
 ---------------

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "char0n/ffmpeg-php",
+    "type": "library",
+    "description": "PHP wrapper for FFmpeg application",
+    "keywords": ["ffmpeg", "video"],
+    "homepage": "http://freecode.com/projects/ffmpegphp",
+    "license": "New BSD",
+    "authors": [
+        {
+            "name": "char0n (Vladimír Gorej, CodeScale)",
+            "email": "gorej@codescale.net"
+        }
+    ],
+    "require": {
+        "php": ">=5.3"
+    },
+    "autoload": {
+        "classmap": ["."]
+    }
+}


### PR DESCRIPTION
This adds support for the composer package manager. If you haven't used composer before, it's an initiative that has been running for a while as an alternative to Pear. See http://getcomposer.org/ and http://packagist.org/ for more details. There are approx 2.4K PHP libraries already using it including Symfony 2, Zend Framework 2, Doctrine 2, Lithium and lots more. Also it helps your library get exposed to more people via the packagist site
