### PR TITLE
Much faster seeking to get frames much faster.

### DIFF
--- a/FFmpegMovie.php
+++ b/FFmpegMovie.php
@@ -675,11 +675,24 @@ class FFmpegMovie implements Serializable {
         
 		$output = array();
 		
+		// fast and accurate way to seek. First quick-seek before input up to
+		// a point just before the frame, and then accurately seek after input
+		// to the exact point.
+		// See: http://ffmpeg.org/trac/ffmpeg/wiki/Seeking%20with%20FFmpeg
+		if ($frameTime > 30) {
+			$seek1 = $frameTime - 30;
+			$seek2 = 30;
+		} else {
+			$seek1 = 0;
+			$seek2 = $frameTime;
+		}
+
         exec(implode(' ', array(
             $this->ffmpegBinary,
+            '-ss '.$seek1,
             '-i '.escapeshellarg($this->movieFile),
             '-f image2',
-            '-ss '.$frameTime,
+            '-ss '.$seek2,
             '-vframes 1',            
             $image_size,
             $quality,


### PR DESCRIPTION
This is a much faster way to grab frames from a video. Seeking aftering the the -i flag causes the video to load all frames right up to $frameTime. In a large movie file this is extremely slow. Instead, you can seek quickly before the input file is loaded with -i, but this isn't quite as accurate as having the -ss after the -i. But, there's a fast & accurate way to seek ahead, which is to quick-seek to a point close to $frameTime, and then accurately seek from there to $frameTime using a second -ss option. See http://ffmpeg.org/trac/ffmpeg/wiki/Seeking%20with%20FFmpeg for a thorough explanation. This makes grabbing frames more than a minute or two into a large movie 100x (or more) faster as it gets progressively slower the further into the video the frame is with -i before -ss.
