### PR TITLE
added getRotation() and test

### DIFF
--- a/FFmpegMovie.php
+++ b/FFmpegMovie.php
@@ -31,6 +31,7 @@ class FFmpegMovie implements Serializable {
     protected static $REGEX_HAS_AUDIO           = '/Stream.+Audio/';
     protected static $REGEX_HAS_VIDEO           = '/Stream.+Video/';
     protected static $REGEX_ERRORS              = '/.*(Error|Permission denied|could not seek to position|Invalid pixel format|Unknown encoder|could not find codec|does not contain any stream).*/i';
+    protected static $REGEX_ROTATION             = '/rotate\s*[:=]\s*(-?[0-9]+)/';
 
     /**
      * FFmpeg binary
@@ -132,6 +133,12 @@ class FFmpegMovie implements Serializable {
     */
     protected $frameWidth;
     /**
+  	* Movie rotiation
+    *
+    * @var int
+    */
+    protected $rotation;
+	/**
     * Movie pixel format
     * 
     * @var string
@@ -445,7 +452,23 @@ class FFmpegMovie implements Serializable {
         
         return $this->frameWidth;
     }
-    
+   
+    /**
+     * Return the rotation angle of the video file
+     *
+     * @return into
+     */
+    public function getRotation()
+    {
+        if ($this->rotation === null) {
+            $match = array();
+            preg_match(self::$REGEX_ROTATION, $this->output, $match);
+            $this->rotation = (array_key_exists(1, $match)) ? intval(trim($match[1])) : 0;
+        }
+
+        return $this->rotation;
+    }
+ 
     /**
     * Return the pixel format of the movie.
     *

--- a/test/FFmpegMovieTest.php
+++ b/test/FFmpegMovieTest.php
@@ -152,6 +152,11 @@ class FFmpegMovieTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(640, $this->movie->getFrameWidth(), 'Frame width should be int(640)');
     }   
     
+	public function ttetGetRotation() {
+		$this->assertInternalType('int', $this->movie->getRotation(), 'Frame rotation is of integer type');
+		$this->assertEquals(0, $this->movie->getRotation(), 'Frame roation should be int(0)');
+	}
+
     public function testGetPixelFormat() {
         $this->assertInternalType('string', $this->movie->getPixelFormat(), 'Pixel format is of string type');
         $this->assertEquals('yuv420p', $this->movie->getPixelFormat(), 'Pixel format should be string(yuv420p)');


### PR DESCRIPTION
I've added an FFmpegMovie->getRotation() method and test to return the rotation, or 0, of the movie file. This is particularly useful when dealing with movies that have been recorded portrait on mobile phones and where the width and height parameters should be transposed for presentation.

I've not changed the values returned from getFrameWidth() and getFrameHeight() when the getRotation() values is 90 or -90, though this should possible be discussed in future, it would be  a breaking change to the API. 