### PR TITLE
PHP8.0 GdImage Change

### DIFF
--- a/src/Frame.php
+++ b/src/Frame.php
@@ -48,7 +48,7 @@ class Frame implements \Serializable
      */
     public function __construct($gdImage, $pts = 0.0)
     {
-        if (!(is_resource($gdImage) && 'gd' === get_resource_type($gdImage))) {
+        if ((!(is_resource($gdImage) && 'gd' === get_resource_type($gdImage))) && !($gdImage instanceof \GdImage)) {
             throw new \UnexpectedValueException(
                 'Param given by constructor is not valid gd resource',
                 self::$EX_CODE_NO_VALID_RESOURCE


### PR DESCRIPTION
PHP8.0 changed GdImage to no longer be a resource but instead be an instance of GdImage.
This updates the Frame constructor to be compliant with this change. (While also still be compatible with earlier versions)
https://php.watch/versions/8.0/gdimage