### PR TITLE
fixed Tests class names

### DIFF
--- a/tests/FrameTest.php
+++ b/tests/FrameTest.php
@@ -6,7 +6,7 @@ use Char0n\FFMpegPHP\Movie;
 use Char0n\FFMpegPHP\Frame;
 use PHPUnit\Framework\TestCase;
 
-class FFmpegFrameTest extends TestCase
+class FrameTest extends TestCase
 {
 
     protected static $moviePath;

--- a/tests/OutputProviders/FFMpegProviderTest.php
+++ b/tests/OutputProviders/FFMpegProviderTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 use SebastianBergmann\Timer\Timer;
 use Char0n\FFMpegPHP\OutputProviders\FFMpegProvider;
 
-class FFmpegProviderTest extends TestCase
+class FFMpegProviderTest extends TestCase
 {
 
     protected static $moviePath;

--- a/tests/OutputProviders/FFProbeProviderTest.php
+++ b/tests/OutputProviders/FFProbeProviderTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\TestCase;
 use SebastianBergmann\Timer\Timer;
 use Char0n\FFMpegPHP\OutputProviders\FFProbeProvider;
 
-class FFProbeOutputProviderTest extends TestCase
+class FFProbeProviderTest extends TestCase
 {
 
     protected static $moviePath;


### PR DESCRIPTION
This fixes composer warnings about wrong PSR-4 locations by syncing test file names with class names:

>Class Char0n\FFMpegPHP\Tests\FFmpegFrameTest located in ./vendor/codescale/ffmpeg-php/tests/FrameTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Char0n\FFMpegPHP\Tests\OutputProviders\FFmpegProviderTest located in ./vendor/codescale/ffmpeg-php/tests/OutputProviders/FFMpegProviderTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Char0n\FFMpegPHP\Tests\OutputProviders\FFProbeOutputProviderTest located in ./vendor/codescale/ffmpeg-php/tests/OutputProviders/FFProbeProviderTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Char0n\FFMpegPHP\Tests\FFmpegAnimatedGifTest located in ./vendor/codescale/ffmpeg-php/tests/AnimatedGifTest.php does not comply with psr-4 autoloading standard. Skipping.
